### PR TITLE
Fix to getBaseTable when using $strict = true. Before strict was esse…

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -445,9 +445,9 @@ class Connection
     public function getBaseTable(string $table, bool $strict = false): string
     {
         return match (true) {
-            !str_starts_with($table, $this->tablePrefix)  => $table,
-            $strict && $this->tableExists($table, false)  => $table,
-            default                                       => substr($table, strlen($this->tablePrefix)),
+            !str_starts_with($table, $this->tablePrefix) => $table,
+            $strict && !$this->tableExists($table, true) => throw new InvalidArgumentException("Table '$table' does not exist"),
+            default => substr($table, strlen($this->tablePrefix)),
         };
     }
 


### PR DESCRIPTION
When $strict = true and $table = "cms_users" (already prefixed), the second arm calls $this->tableExists("cms_users", false). Since $isFullTable is false, tableExists() prepends the prefix again, checking for "cms_cms_users" -- which almost certainly doesn't exist. So the strict validation never fires, and the method silently falls through to the default arm. Additionally, if the double-prefixed table did exist, it returns $table with the prefix, which is wrong for a method called "getBase."

This leads to the function returning tables that don't exist even when using $strict = true. This fix makes it throw an exception when the table really doesn't exist.