### PR TITLE
Added handling for cloned connections. Clones before shared the mysql…

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -29,6 +29,8 @@ class Connection
 {
     use ConnectionInternals;
 
+    private bool $ownsConnection = true;
+
     //region Public Properties
 
     /**
@@ -190,12 +192,14 @@ class Connection
     }
 
     /**
-     * Disconnect from the database.
+     * Disconnect from the database if it owns the connection (not a clone).
      */
     public function disconnect(): void
     {
         if ($this->mysqli instanceof mysqli) {
-            $this->mysqli->close();
+            if ($this->ownsConnection) {
+                $this->mysqli->close();
+            }
             $this->mysqli = null;
         }
     }
@@ -213,6 +217,7 @@ class Connection
     public function clone(array $config = []): self
     {
         $clone = clone $this;
+        $clone->ownsConnection = false;  // Clones don't own the connection
         foreach ($config as $key => $value) {
             if (!property_exists($clone, $key)) {
                 throw new InvalidArgumentException("Unknown configuration key: '$key'");


### PR DESCRIPTION
Connection objects should probably track their ownership to the underlying database connection. Making clones shares the underlying connection and so if any clone was to kill its connection, all clones (and original connection) would keep a disconnected connection and throw errors upon use. 

This change proposes keeping track of the connection and all clones would set its owner flag to false during cloning so that unless the clone itself owns the connection, it won't close it on all other clones. Only the original owner can close its connection.